### PR TITLE
Upgrade to WildFly 26.0.0.Final and config adjustments

### DIFF
--- a/common/src/main/resources/configs/standalone/model.xml
+++ b/common/src/main/resources/configs/standalone/model.xml
@@ -12,5 +12,6 @@
     <layers>
         <!-- required for termination and script execution -->
         <include name="core-tools"/>
+        <include name="health"/>
     </layers>
 </config>

--- a/common/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/common/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -28,6 +28,12 @@
     <packages>
         <package name="modules.all"/>
     </packages>
+    
+    <exclude spec="subsystem.core-management"/>
+    
+    <!-- disable the web-console -->
+    <feature-group name="os-management"/>
+
     <exclude spec="subsystem.microprofile-opentracing-smallrye"/>
 
     <!-- The layer secures it with elytron -->
@@ -72,5 +78,9 @@ env.OPENSHIFT_DEFAULT_DATASOURCE,env.EXAMPLE_DATASOURCE,env.OPENSHIFT_EXAMPLE_DA
     <exclude spec="subsystem.infinispan"/>
     <exclude spec="subsystem.distributable-web"/>
     <feature-group name="os-clustering"/>
+
+    <!-- undertow -->
+    <exclude feature-id="subsystem.undertow.server.https-listener:server=default-server,https-listener=https"/>
+    <feature-group name="os-undertow"/>
 
 </config>

--- a/common/src/main/resources/feature_groups/os-management.xml
+++ b/common/src/main/resources/feature_groups/os-management.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Once we get rid-off of WildFly s2i v1, this feature-group can be moved to wildfly-cekit-modules for sharing -->
+<feature-group-spec name="os-management" xmlns="urn:jboss:galleon:feature-group:1.0">
+   <feature spec="core-service.management.management-interface.http-interface">
+        <param name="console-enabled" value="false"/>
+    </feature>
+</feature-group-spec>

--- a/common/src/main/resources/feature_groups/os-undertow.xml
+++ b/common/src/main/resources/feature_groups/os-undertow.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Once we get rid-off of WildFly s2i v1, this feature-group can be moved to wildfly-cekit-modules for sharing -->
+<feature-group-spec name="os-undertow" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.undertow">
+        <feature spec="subsystem.undertow.server">
+            <param name="server" value="default-server" />
+            <feature spec="subsystem.undertow.server.http-listener">
+                <param name="http-listener" value="default"/>
+                <param name="proxy-address-forwarding" value="true"/>
+            </feature>
+        </feature>
+    </feature>
+</feature-group-spec>

--- a/common/src/main/resources/layers/standalone/management/layer-spec.xml
+++ b/common/src/main/resources/layers/standalone/management/layer-spec.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<!-- Once we get rid-off of WildFly s2i v1, this feature-group can be moved to wildfly-cekit-modules for sharing -->
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="management">
+   <feature-group name="os-management"/>
+</layer-spec>

--- a/common/src/main/resources/layers/standalone/undertow/layer-spec.xml
+++ b/common/src/main/resources/layers/standalone/undertow/layer-spec.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<!-- Once we get rid-off of WildFly s2i v1, this feature-group can be moved to wildfly-cekit-modules for sharing -->
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="undertow">
+    <feature-group name="os-undertow"/>
+</layer-spec>
+

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
     
     <properties>
         <version.junit>4.13.2</version.junit>
-        <version.org.wildfly>26.0.0.Beta1</version.org.wildfly>
-        <version.org.wildfly.core>18.0.0.Beta5</version.org.wildfly.core>
-        <version.org.wildfly.galleon-plugins>5.2.6.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly>26.0.0.Final</version.org.wildfly>
+        <version.org.wildfly.core>18.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.galleon-plugins>5.2.8.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugin>3.0.0.Alpha3</version.org.wildfly.maven.plugin>
     </properties>
 


### PR DESCRIPTION
This fix the issue #9 
Removes https from the default config,
Enforce health to be provisioned.
Enable proxy-forwarding for undertow.
